### PR TITLE
Initialize array for php 7.2 compatibility

### DIFF
--- a/src/Svg/Tag/AbstractTag.php
+++ b/src/Svg/Tag/AbstractTag.php
@@ -2,7 +2,7 @@
 /**
  * @package php-svg-lib
  * @link    http://github.com/PhenX/php-svg-lib
- * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @author  Fabien MÃ©nager <fabien.menager@gmail.com>
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 
@@ -21,7 +21,7 @@ abstract class AbstractTag
     /** @var Style */
     protected $style;
 
-    protected $attributes;
+    protected $attributes = array();
 
     protected $hasShape = true;
 


### PR DESCRIPTION
With PHP7.2 i get the following error:

Warning: count(): Parameter must be an array or an object that implements Countable

This fix repairs this issue.
