### PR TITLE
Support (non-visible) desc attribute

### DIFF
--- a/src/Svg/Document.php
+++ b/src/Svg/Document.php
@@ -2,7 +2,7 @@
 /**
  * @package php-svg-lib
  * @link    http://github.com/PhenX/php-svg-lib
- * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @author  Fabien MÃ©nager <fabien.menager@gmail.com>
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 
@@ -333,6 +333,9 @@ class Document extends AbstractTag
             case 'text':
                 $tag = new Text($this, $name);
                 break;
+
+            case 'desc':
+                return;
         }
 
         if ($tag) {


### PR DESCRIPTION
Prevents 'Unknown: desc' when using the `desc` tag. See https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc

> Each container element or graphics element in an SVG drawing can supply a description string using the <desc> element where the description is text-only.
> When the current SVG document fragment is rendered as SVG on visual media, <desc> elements are not rendered as part of the graphics. [..]

We don't need to render it, but avoid the echo of invalid tag (which should probably trigger an exception/warning instead of echo?)