### PR TITLE
Make sure $attributes is an array

### DIFF
--- a/src/Svg/Tag/AbstractTag.php
+++ b/src/Svg/Tag/AbstractTag.php
@@ -2,7 +2,7 @@
 /**
  * @package php-svg-lib
  * @link    http://github.com/PhenX/php-svg-lib
- * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @author  Fabien MÃ©nager <fabien.menager@gmail.com>
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 
@@ -21,7 +21,7 @@ abstract class AbstractTag
     /** @var Style */
     protected $style;
 
-    protected $attributes;
+    protected $attributes = array();
 
     protected $hasShape = true;
 


### PR DESCRIPTION
Otherwise the `count()` in Document will fail. This will make sure that $attributes is an array as expected, before initialized.
```php
if (count($this->attributes)) {
     $tag = new Group($this, $name);
}
```