### PR TITLE
Add branch alias for 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "0.3-dev"
+    }
   }
 }


### PR DESCRIPTION
So people can require the dev version easyily (with `0.3.x@dev`) while still fulfilling the dompdf requirements.