### PR TITLE
declaring and initializing variable attributes

### DIFF
--- a/src/Svg/Document.php
+++ b/src/Svg/Document.php
@@ -40,6 +40,7 @@ class Document extends AbstractTag
     protected $subPathInit;
     protected $pathBBox;
     protected $viewBox;
+    protected $attributes = [];
 
     /** @var resource */
     protected $parser;


### PR DESCRIPTION
on php7.2 was returning the error 
"count(): Parameter must be an array or an object that implements Countable" 
file: phenx/php-svg-lib/src/Svg/Document.php 
line: 259

Reason:
 Variable $this->attributes wasn't declared and Php was reading count(null)