### PR TITLE
Removes count of non countable value

### DIFF
--- a/src/Svg/Document.php
+++ b/src/Svg/Document.php
@@ -2,7 +2,7 @@
 /**
  * @package php-svg-lib
  * @link    http://github.com/PhenX/php-svg-lib
- * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @author  Fabien Mï¿½nager <fabien.menager@gmail.com>
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 
@@ -256,7 +256,7 @@ class Document extends AbstractTag
                 return;
 
             case 'svg':
-                if (count($this->attributes)) {
+                if ($this->attributes) {
                     $tag = new Group($this, $name);
                 }
                 else {


### PR DESCRIPTION
This pull request fix the incorrect use of the `count()` function in PHP 7.2. 