### PR TITLE
Fix for PHP7.2 count()

### DIFF
--- a/src/Svg/Document.php
+++ b/src/Svg/Document.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * @package php-svg-lib
  * @link    http://github.com/PhenX/php-svg-lib
@@ -256,7 +256,7 @@ class Document extends AbstractTag
                 return;
 
             case 'svg':
-                if (count($this->attributes)) {
+                if (count($this->attributes ?? [])) {
                     $tag = new Group($this, $name);
                 }
                 else {


### PR DESCRIPTION
PHP changed the way they count by requiring a Countable to be inserted as value for the `count()` function
The `_tagStart` method tried to count `$this->attributes` which in somecases equals `NULL`
With the added fix it will ensure it is a valid Countable, it will return an empty array if the value is `NULL`

My error: 
ErrorException: count(): Parameter must be an array or an object that implements Countable in ~\vendor\phenx\php-svg-lib\src\Svg\Document.php:259