### PR TITLE
Fixed a memory leak

### DIFF
--- a/src/Svg/Document.php
+++ b/src/Svg/Document.php
@@ -41,9 +41,6 @@ class Document extends AbstractTag
     protected $pathBBox;
     protected $viewBox;
 
-    /** @var resource */
-    protected $parser;
-
     /** @var SurfaceInterface */
     protected $surface;
 
@@ -74,7 +71,7 @@ class Document extends AbstractTag
             array($this, "_charData")
         );
 
-        return $this->parser = $parser;
+        return $parser;
     }
 
     public function __construct() {


### PR DESCRIPTION
The XML parser callback combined with the class level reference to the XML parser create a reference loop which can not be resolved by the PHP garbage collector. Therefore to prevent memory leaks either the class level reference should be cleaned (or not exist at all), or the parser callbacks should be unset (NULL) during cleanup. Just removing the class level reference, which as far as I can tell is not used anywhere, seems to be the easiest way.

Test case demonstrating the XML parser memory leak:
```
<?php
class A {
        function __construct() {
                $parser = xml_parser_create("utf-8");
                xml_set_element_handler($parser, [$this, 'a'], NULL); //commenting this out fixes the problem
              $this->parser = $parser; //commenting this out fixes the problem
                xml_parser_free($parser);
//              $this->parser = NULL; //uncommenting this fixes the problem
        }
        function a() {
        }
}

for ($i = 0; $i < 1000; $i++) {
        for ($j = 0; $j < 1000; $j++) new A();
        echo memory_get_usage().PHP_EOL;
}
```

The bug affects PHP7.1 and 7.2, and is probably something that should be fixed in PHP, but that will probably take a lot more time than this simple fix.