### PR TITLE
Fixed wrong handling of percentual height/width of rectangels

### DIFF
--- a/src/Svg/Tag/Rect.php
+++ b/src/Svg/Tag/Rect.php
@@ -27,10 +27,20 @@ class Rect extends Shape
         }
 
         if (isset($attributes['width'])) {
-            $this->width = $attributes['width'];
+            if ('%' === substr($attributes['width'], -1)) {
+                $factor = substr($attributes['width'], 0, -1) / 100;
+                $this->width = $this->document->getWidth() * $factor;
+            } else {
+                $this->width = $attributes['width'];
+            }
         }
         if (isset($attributes['height'])) {
-            $this->height = $attributes['height'];
+            if ('%' === substr($attributes['height'], -1)) {
+                $factor = substr($attributes['height'], 0, -1) / 100;
+                $this->height = $this->document->getHeight() * $factor;
+            } else {
+                $this->height = $attributes['height'];
+            }
         }
 
         if (isset($attributes['rx'])) {


### PR DESCRIPTION
If the dimensions of a rectangular are given in percentual values, the values are handled as if they were absolute ones.

This PR addresses this issue and ensures that percentual dimensions get calculated.