### PR TITLE
Extended rotate transformation to support rotation about another point

### DIFF
--- a/src/Svg/Tag/AbstractTag.php
+++ b/src/Svg/Tag/AbstractTag.php
@@ -166,7 +166,8 @@ abstract class AbstractTag
                         break;
 
                     case "rotate":
-                        if (isset($t[2]) || isset($t[3])) {
+                        if (isset($t[2])) {
+                            $t[3] = isset($t[3]) ? $t[3] : 0;
                             $surface->translate($t[2], $t[3]);
                             $surface->rotate($t[1]);
                             $surface->translate(-$t[2], -$t[3]);

--- a/src/Svg/Tag/AbstractTag.php
+++ b/src/Svg/Tag/AbstractTag.php
@@ -166,7 +166,13 @@ abstract class AbstractTag
                         break;
 
                     case "rotate":
-                        $surface->rotate($t[1]);
+                        if (isset($t[2]) || isset($t[3])) {
+                            $surface->translate($t[2], $t[3]);
+                            $surface->rotate($t[1]);
+                            $surface->translate(-$t[2], -$t[3]);
+                        } else {
+                            $surface->rotate($t[1]);
+                        }
                         break;
 
                     case "skewX":


### PR DESCRIPTION
SVG supports the rotation of an element about another point (see [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform#Rotate)). php-svg-lib did not support this before. So I added this feature.

This fixes issue  #15.

I got the idea for the implementation from https://github.com/deeplook/svglib/. Credits to @deeplook.