### PR TITLE
Improve parsing of arc segments

### DIFF
--- a/src/Svg/Tag/Path.php
+++ b/src/Svg/Tag/Path.php
@@ -2,7 +2,7 @@
 /**
  * @package php-svg-lib
  * @link    http://github.com/PhenX/php-svg-lib
- * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @author  Fabien Menager <fabien.menager@gmail.com>
  * @license GNU LGPLv3+ http://www.gnu.org/copyleft/lesser.html
  */
 
@@ -29,16 +29,10 @@ class Path extends Shape
         'M' => 'L',
     );
 
-    public function start($attributes)
+    public static function parse(string $commandSequence): array
     {
-        if (!isset($attributes['d'])) {
-            $this->hasShape = false;
-
-            return;
-        }
-
         $commands = array();
-        preg_match_all('/([MZLHVCSQTAmzlhvcsqta])([eE ,\-.\d]+)*/', $attributes['d'], $commands, PREG_SET_ORDER);
+        preg_match_all('/([MZLHVCSQTAmzlhvcsqta])([eE ,\-.\d]+)*/', $commandSequence, $commands, PREG_SET_ORDER);
 
         $path = array();
         foreach ($commands as $c) {
@@ -75,6 +69,18 @@ class Path extends Shape
             }
         }
 
+        return $path;
+    }
+
+    public function start($attributes)
+    {
+        if (!isset($attributes['d'])) {
+            $this->hasShape = false;
+
+            return;
+        }
+
+        $path = static::parse($attributes['d']);
         $surface = $this->document->getSurface();
 
         // From https://github.com/kangax/fabric.js/blob/master/src/shapes/path.class.js

--- a/tests/Svg/PathTest.php
+++ b/tests/Svg/PathTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Svg\Tests;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Svg\Document;
+use Svg\Surface\SurfaceCpdf;
+use Svg\Tag\Path;
+
+final class PathTest extends TestCase
+{
+    public function commandProvider(): array
+    {
+        return [
+            'parse a relative arc with the shorthand format' => [
+                'a12.083 12.083 0 01.665 6.479',
+                [
+                    [
+                        'a',
+                        12.083,
+                        12.083,
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.665,
+                        6.479,
+                    ],
+                ],
+            ],
+            'parse an absolute arc with the shorthand format' => [
+                'A12.083 12.083 0 01.665 6.479',
+                [
+                    [
+                        'A',
+                        12.083,
+                        12.083,
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.665,
+                        6.479,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider commandProvider
+     * @param string $commandSequence
+     * @param array $expected
+     */
+    public function testParseCommands(string $commandSequence, array $expected)
+    {
+        $result = Path::parse($commandSequence);
+
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
Fixes #11 and dompdf/dompdf#1301. The logic is borrowed from [fabric.js](https://github.com/fabricjs/fabric.js/blob/3a6029a93d7d1368980e64cbb97c87b0f2daeec4/src/util/path.js#L664).