### PR TITLE
Add paths and folders to be export-ignored to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,9 @@
 *.html  text
 *.htm   text
 *.svg   text
+
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.travis.yml      export-ignore
+/phpunit.xml      export-ignore
+/tests            export-ignore


### PR DESCRIPTION
Add paths to `.gitattributes` with the export-ignore flag set, so they're not pulled down as part of a project's dependencies via Composer.