### PR TITLE
Changed the attribute merging logic of `<use/>` tags to better align with spec

### DIFF
--- a/src/Svg/Tag/UseTag.php
+++ b/src/Svg/Tag/UseTag.php
@@ -69,12 +69,18 @@ class UseTag extends AbstractTag
             return;
         }
 
-        $attributes = array_merge($this->reference->attributes, $attributes);
+        $mergedAttributes = $this->reference->attributes;
+        $attributesToNotMerge = ['x', 'y', 'width', 'height'];
+        foreach ($attributes as $attrKey => $attrVal) {
+            if (!in_array($attrKey, $attributesToNotMerge) && !isset($mergedAttributes[$attrKey])) {
+                $mergedAttributes[$attrKey] = $attrVal;
+            }
+        }
 
-        $this->reference->handle($attributes);
+        $this->reference->handle($mergedAttributes);
 
         foreach ($this->reference->children as $_child) {
-            $_attributes = array_merge($_child->attributes, $attributes);
+            $_attributes = array_merge($_child->attributes, $mergedAttributes);
             $_child->handle($_attributes);
         }
     }


### PR DESCRIPTION
#### Change Detail

This PR changes the attribute merging logic of `<use>` tags to better align with the spec and other SVG renders. 

Previously, `<use>` tag attributes would be directly merged to child items, with the tags of the use tag taking priority.
This has been changed so that the child item attributes instead take priority. Relevant detail from [MDN docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use):

> Most attributes on use do not override those already on the element referenced by use. [...] . Only the attributes [x](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x), [y](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/y), [width](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width), [height](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height) and [href](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href) on the use element will override those set on the referenced element. However, any other attributes not set on the referenced element will be applied to the use element.

As per the above statement; width, height, x, y are handled different. These are essentially ignored during merge now. As far as I can see, we don't currently need to handle width and height (Apart from preventing application to child content), as these only are used when a new viewport is created which I don't think is yet an occurrence in this library (Would be during symbol/svg handling which are currently just treated as groups). [Relevant detail from SVG spec](https://svgwg.org/svg2-draft/struct.html#UseLayout):

> The [width](https://svgwg.org/svg2-draft/geometry.html#Sizing) and [height](https://svgwg.org/svg2-draft/geometry.html#Sizing) properties on the ‘[use](https://svgwg.org/svg2-draft/struct.html#UseElement)’ element have no effect if the [referenced element](https://svgwg.org/svg2-draft/struct.html#TermReferencedElement) does not [establish a new viewport](https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport).

For the x & y attributes, a surface translation was already being applied for these properties in the `before` function of the tag which [aligns with the layout detail of the spec](https://svgwg.org/svg2-draft/struct.html#UseLayout).
Previously, these attributes would then be copied to children and cause a non-intended double offsetting on items that used x/y positioning attributes. This PR prevents this from occurring. 

#### Related Issues

- This should fix #57.

#### Testing Performed

<details>
<summary>Test PHP Script</summary>

```php
<?php

use Svg\Document;
use Svg\Surface\SurfaceCpdf;

require __DIR__ . '/vendor/autoload.php';

$inputSvgFile = __DIR__ . '/test.svg';
$outputPdfFile = __DIR__ . '/test.pdf';

$doc = new Document();
$doc->loadFile($inputSvgFile);

$surface = new SurfaceCpdf($doc);
$doc->render($surface);

$output = $surface->out();

file_put_contents($outputPdfFile, $output);
```

</details>

- [Test SVG Input File](https://user-images.githubusercontent.com/8343178/170526507-7ec9576e-e205-4506-8196-70efc5abbd1d.svg)
- [Pre-Change Output](https://github.com/dompdf/php-svg-lib/files/8780327/test.pdf)
- [Post-Change Output](https://github.com/dompdf/php-svg-lib/files/8780322/test.pdf)

#### Notes

- As per my other PR, I have great admiration and respect for the efforts of the project. Feel free to direct me on contribution format/scope/style/etc.. as required, or if this has to be closed without merge for some reason I'll understand.

