### PR TITLE
allow php-css-parser ^9 while keeping ^8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^7.1 || ^8.0",
     "ext-mbstring": "*",
-    "sabberworm/php-css-parser": "^8.4"
+    "sabberworm/php-css-parser": "^8.4 || ^9.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"


### PR DESCRIPTION
This PR allows `php-svg-lib` to work with projects on `Sabberworm 9` (which includes `PHP 8.5` support) while remaining compatible with existing `8.x` users.