### PR TITLE
Vary style Rule value handling based on type

### DIFF
--- a/src/Svg/Style.php
+++ b/src/Svg/Style.php
@@ -109,6 +109,7 @@ class Style
         $class = isset($attributes["class"]) ? preg_split('/\s+/', trim($attributes["class"])) : null;
 
         $stylesheets = $tag->getDocument()->getStyleSheets();
+        $outputFormat = \Sabberworm\CSS\OutputFormat::createCompact();
 
         $styles = array();
 
@@ -127,7 +128,12 @@ class Style
                             if ($_selector === ".$_class") {
                                 /** @var \Sabberworm\CSS\Rule\Rule $_rule */
                                 foreach ($_decl->getRules() as $_rule) {
-                                    $styles[$_rule->getRule()] = $_rule->getValue()->render() . "";
+                                    $value = $_rule->getValue();
+                                    if ($value instanceof \Sabberworm\CSS\Value\Value) {
+                                        $styles[$_rule->getRule()] = $value->render($outputFormat) . "";
+                                    } else {
+                                        $styles[$_rule->getRule()] = $value . "";
+                                    }
                                 }
 
                                 break 2;
@@ -139,7 +145,12 @@ class Style
                     if ($_selector === $tag->tagName) {
                         /** @var \Sabberworm\CSS\Rule\Rule $_rule */
                         foreach ($_decl->getRules() as $_rule) {
-                            $styles[$_rule->getRule()] = $_rule->getValue()->render() . "";
+                            $value = $_rule->getValue();
+                            if ($value instanceof \Sabberworm\CSS\Value\Value) {
+                                $styles[$_rule->getRule()] = $value->render($outputFormat) . "";
+                            } else {
+                                $styles[$_rule->getRule()] = $value . "";
+                            }
                         }
 
                         break;


### PR DESCRIPTION
A Rule can return a RuleValueList or a string depending on the CSS property being parsed. A format handler must be supplied when rendering the RuleValueList.